### PR TITLE
Corrects the link for the Github repo in the Contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ others contributing as well (at least we hope).
 
 ```bash
 
-$ git remote add upstream git@github.com:MilSpouseCoders/milspousecoders.git
+$ git remote add upstream https://github.com/MilSpouseCoders/milspousecoders.git
 
 ```
 


### PR DESCRIPTION
closes #8 